### PR TITLE
fix broken links in website

### DIFF
--- a/website/docs/documentation/api.md
+++ b/website/docs/documentation/api.md
@@ -4,11 +4,11 @@ title: API
 
 This page is an overview and a guide for usage.
 
-The API TypeScript definitions are documented [here](../api/modules.md).
+The API TypeScript definitions are documented [here](../api/globals.md).
 
 ## Functions:
 
-### [loadData](/api/modules.md#loaddata)
+### [loadData](../api/functions/loadData.md)
 
 This function loads data from url.
 
@@ -34,7 +34,7 @@ racingBars.loadData('/data/population.csv', 'csv').then((data) => {
 });
 ```
 
-### [race](/api/modules.md#race)
+### [race](../api/functions/race.md)
 
 This is the main function that generates the racing bar chart.
 
@@ -52,7 +52,7 @@ This is the main function that generates the racing bar chart.
   The chart container HTML element or a string representing a CSS selector for it. If not provided, a new `<div>` element is created, added to the document `<body>` and used.
   Note that any content inside that element will be deleted before embedding the chart.
 
-- options: [`Options`](../api/interfaces/internal.Options.md)
+- options: [`Options`](../api/internal/interfaces/Options.md)
 
   An optional configuration object for chart options. The options are documented in the ["Options" section](./options.md)
 
@@ -237,7 +237,7 @@ See the examples for [Slider](../gallery/slider.md) and [Scroller](../gallery/sc
 
 ### [Data](../api/interfaces/Data.md)
 
-### [Options](../api/interfaces/internal.Options.md)
+### [Options](../api/internal/interfaces/Options.md)
 
 ### [Race](../api/interfaces/Race.md)
 

--- a/website/docs/documentation/data.md
+++ b/website/docs/documentation/data.md
@@ -160,7 +160,7 @@ import { race } from 'racing-bars';
 race('long.csv', '#race', { dataType: 'csv' });
 ```
 
-In addition, the [`loadData`](./api.md#loaddataurltype) function can be used to load data from a URL into a JavaScript array.
+In addition, the [`loadData`](./api.md#loaddata) function can be used to load data from a URL into a JavaScript array.
 
 ```js
 import { loadData, race } from 'racing-bars';

--- a/website/docs/documentation/options.md
+++ b/website/docs/documentation/options.md
@@ -223,7 +223,7 @@ const options = {
 race('/data/population.json', '#race', options);
 ```
 
-Note that the transformation could have been done after loading the data with [`loadData`](../documentation/api.md#loaddataurl-type) method and before calling the [`race`](../documentation/api.md#racedata-options) method, as follows:
+Note that the transformation could have been done after loading the data with [`loadData`](../documentation/api.md#loaddata) method and before calling the [`race`](../documentation/api.md#race) method, as follows:
 
 ```js
 import { loadData, race } from 'racing-bars';
@@ -562,7 +562,7 @@ const options = {
 
 ### makeCumulative
 
-If `true`, the values are converted to [cumulative sums](./data.md#cumulativesum) (running totals).
+If `true`, the values are converted to [cumulative sums](./data.md#cumulative-sum) (running totals).
 
 - Type: `boolean`
 - Default: `false`

--- a/website/docs/gallery/keyboard-controls.md
+++ b/website/docs/gallery/keyboard-controls.md
@@ -5,7 +5,7 @@ hide_table_of_contents: true
 
 import RacingBars from '../../src/components/RacingBars';
 
-A demo for using [`keyboardControls`](../documentation/options.md#keyboardControls).
+A demo for using [`keyboardControls`](../documentation/options.md#keyboardcontrols).
 See the guide on [`chart controls`](../guides/chart-controls.md).
 
 <!--truncate-->

--- a/website/docs/getting-started/usage.md
+++ b/website/docs/getting-started/usage.md
@@ -10,13 +10,13 @@ After [installation](./installation.md), you can use the library in JavaScript a
 
 The library exports the [`race`](../documentation/api.md#race) function, which creates the bar chart race. It has the following signature:
 
-Type: [`race(data, container?, options?): Promise<Race>`](../api/modules.md#race)
+Type: [`race(data, container?, options?): Promise<Race>`](../api/functions/race.md)
 
 The function accepts the following parameters:
 
 - `data`:
 
-  Type: [`Data`](/api/interfaces/Data.md)[] | `Promise`&lt;[`Data`](/api/interfaces/Data.md)[]&gt; | [`WideData`](/api/interfaces/WideData.md)[] | `Promise`&lt;[`WideData`](/api/interfaces/WideData.md)[]&gt; | `string`
+  Type: [`Data`](../api/interfaces/Data.md)[] | `Promise`&lt;[`Data`](../api/interfaces/Data.md)[]&gt; | [`WideData`](../api/interfaces/WideData.md)[] | `Promise`&lt;[`WideData`](../api/interfaces/WideData.md)[]&gt; | `string`
 
   The data object, a promise that resolves to it or a URL to it.  
   See [section about data](../documentation/data.md) for details.
@@ -29,7 +29,7 @@ The function accepts the following parameters:
 
 - `options`:
 
-  Type: `Partial`&lt;[`Options`](../api/interfaces/internal.Options.md)&gt;
+  Type: `Partial`&lt;[`Options`](../api/internal/interfaces/Options.md)&gt;
 
   An optional configuration object. See [section about options](../documentation/options.md) for details
 
@@ -57,7 +57,7 @@ race('data/population.csv', '#race', options);
 
 For convenience, the library also exports the [`loadData`](../documentation/api.md#loaddata) function to allow fetching data from URL.
 
-Type: [`loadData(URL, type?): Promise<Data[]> | Promise<WideData[]>`](/api/modules.md#loadData)
+Type: [`loadData(URL, type?): Promise<Data[]> | Promise<WideData[]>`](../api/functions/loadData.md)
 
 It supports the following data formats, by specifying the second optional parameter:
 
@@ -80,7 +80,7 @@ loadData('data/population.csv', 'csv').then((data) => {
 
 ## TypeScript Support
 
-The library supports TypeScript. Documentation for the TypeScript definitions can be found [here](../api/modules.md).
+The library supports TypeScript. Documentation for the TypeScript definitions can be found [here](../api/globals.md).
 
 ```ts
 import { race, type Options } from 'racing-bars';

--- a/website/docs/guides/bar-colors.md
+++ b/website/docs/guides/bar-colors.md
@@ -11,7 +11,7 @@ The color assignment is consistent (every time the chart loads, each bar name ge
 
 If the dataset contains a lot of names (or groups), the bar colors may start becoming near each other.
 
-This default behaviour can be changed in different ways.
+This default behavior can be changed in different ways.
 
 ## Change Default Colors
 
@@ -121,7 +121,7 @@ race('/data/population.json', '#race', options);
 ```
 
 :::info
-Notice that if groups are shown ([showGroups](#showgroups) is set to `true`, and the dataset has the field `group`),
+Notice that if groups are shown ([showGroups](../documentation/options.md#showgroups) is set to `true`, and the dataset has the field `group`),
 [`colorMap`](../documentation/options.md#colormap) option affects `group` colors, otherwise it affects `name` colors, but not both.
 :::
 

--- a/website/docs/guides/chart-size.md
+++ b/website/docs/guides/chart-size.md
@@ -2,7 +2,7 @@
 title: Chart Size
 ---
 
-By default the chart will take the size of the [container element](../getting-started/usage.md#race).
+By default the chart will take the size of the [container element](../documentation/api.md#race).
 So, the chart can be easily sized by sizing that element (e.g. by CSS).
 
 Example:

--- a/website/docs/guides/themes-styles.md
+++ b/website/docs/guides/themes-styles.md
@@ -142,7 +142,7 @@ Example:
 
 The chart styles are defined in CSS which is bundled in the JS library.
 When the chart loads, the styles are dynamically injected in the top of the HTML document head.
-The styles are scoped to the element specified by the [`selector`](../documentation/options.md#selector) option.
+The styles are scoped to the [container element](../documentation/api.md#race).
 
 The CSS used can be <a href="https://github.com/hatemhosny/racing-bars/tree/master/src/lib/css" target="_blank" className="external">found here</a>.
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
   organizationName: 'hatemhosny', // Usually your GitHub org/user name.
   projectName: 'racing-bars', // Usually your repo name.
-  onBrokenLinks: 'warn',
+  onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
@@ -107,7 +107,7 @@ const config: Config = {
             },
             {
               label: 'Sponsor 💚',
-              href: 'sponsor',
+              to: 'sponsor',
             },
           ],
         },


### PR DESCRIPTION
This PR fixes the broken links in website after upgrading docusaurus & typedoc as discussed here: https://github.com/hatemhosny/racing-bars/pull/164

The new version of typedoc generates a different file structure than the one previously used which caused links to break.